### PR TITLE
feat: Expose primitive selectors directly to commands directly

### DIFF
--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -7,10 +7,17 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
+	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/sestrella/iecs/client"
 	"github.com/sestrella/iecs/selector"
 	"github.com/spf13/cobra"
 )
+
+type SelectedContainerDefinition struct {
+	Cluster             *types.Cluster
+	Service             *types.Service
+	ContainerDefinition *types.ContainerDefinition
+}
 
 var logsCmd = &cobra.Command{
 	Use:   "logs",
@@ -40,28 +47,40 @@ func runLogs(
 	client client.Client,
 	selectors selector.Selectors,
 ) error {
-	selection, err := selectors.ContainerDefinitionSelector(ctx)
+	selection, err := containerDefinitionSelector(ctx, selectors)
 	if err != nil {
 		return err
 	}
 
 	if selection.ContainerDefinition.LogConfiguration == nil {
-		return fmt.Errorf("no log configuration found for container: %s", *selection.ContainerDefinition.Name)
+		return fmt.Errorf(
+			"no log configuration found for container: %s",
+			*selection.ContainerDefinition.Name,
+		)
 	}
 
 	logOptions := selection.ContainerDefinition.LogConfiguration.Options
 	if len(logOptions) == 0 {
-		return fmt.Errorf("missing log options for container: %s", *selection.ContainerDefinition.Name)
+		return fmt.Errorf(
+			"missing log options for container: %s",
+			*selection.ContainerDefinition.Name,
+		)
 	}
 
 	awslogsGroup, ok := logOptions["awslogs-group"]
 	if !ok {
-		return fmt.Errorf("missing awslogs-group option for container: %s", *selection.ContainerDefinition.Name)
+		return fmt.Errorf(
+			"missing awslogs-group option for container: %s",
+			*selection.ContainerDefinition.Name,
+		)
 	}
 
 	streamPrefix, ok := logOptions["awslogs-stream-prefix"]
 	if !ok {
-		return fmt.Errorf("missing awslogs-stream-prefix option for container: %s", *selection.ContainerDefinition.Name)
+		return fmt.Errorf(
+			"missing awslogs-stream-prefix option for container: %s",
+			*selection.ContainerDefinition.Name,
+		)
 	}
 
 	// Use our logs client to start the live tail
@@ -78,6 +97,32 @@ func runLogs(
 	}
 
 	return nil
+}
+
+func containerDefinitionSelector(
+	ctx context.Context,
+	selectors selector.Selectors,
+) (*SelectedContainerDefinition, error) {
+	cluster, err := selectors.Cluster(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	service, err := selectors.Service(ctx, cluster)
+	if err != nil {
+		return nil, err
+	}
+
+	containerDefinition, err := selectors.ContainerDefinition(ctx, service)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SelectedContainerDefinition{
+		Cluster:             cluster,
+		Service:             service,
+		ContainerDefinition: containerDefinition,
+	}, nil
 }
 
 func init() {

--- a/cmd/logs_test.go
+++ b/cmd/logs_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/sestrella/iecs/client"
-	"github.com/sestrella/iecs/selector"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -51,13 +50,10 @@ func TestRunLogs_Success(t *testing.T) {
 		LogConfiguration: logConfiguration,
 	}
 
-	selectedContainerDefinition := &selector.SelectedContainerDefinition{
-		Cluster:             cluster,
-		Service:             service,
-		ContainerDefinition: containerDefinition,
-	}
-
-	mockSel.On("ContainerDefinitionSelector", mock.Anything).Return(selectedContainerDefinition, nil)
+	// Setup mock calls for selectors
+	mockSel.On("Cluster", mock.Anything).Return(cluster, nil)
+	mockSel.On("Service", mock.Anything, cluster).Return(service, nil)
+	mockSel.On("ContainerDefinition", mock.Anything, service).Return(containerDefinition, nil)
 	mockClient.On("StartLiveTail", mock.Anything, "/ecs/my-service", "ecs", mock.AnythingOfType("client.EventHandler")).Return(nil)
 
 	// Test the function
@@ -74,9 +70,9 @@ func TestRunLogs_SelectorError(t *testing.T) {
 	mockClient := new(MockClient)
 	mockSel := new(MockSelectors)
 
-	// Setup mock responses with an error
-	expectedErr := errors.New("container definition selector error")
-	mockSel.On("ContainerDefinitionSelector", mock.Anything).Return(nil, expectedErr)
+	// Setup mock responses with an error for cluster selector
+	expectedErr := errors.New("cluster selector error")
+	mockSel.On("Cluster", mock.Anything).Return(nil, expectedErr)
 
 	// Test the function
 	err := runLogs(context.Background(), mockClient, mockSel)
@@ -117,13 +113,10 @@ func TestRunLogs_MissingLogConfiguration(t *testing.T) {
 		LogConfiguration: nil,
 	}
 
-	selectedContainerDefinition := &selector.SelectedContainerDefinition{
-		Cluster:             cluster,
-		Service:             service,
-		ContainerDefinition: containerDefinition,
-	}
-
-	mockSel.On("ContainerDefinitionSelector", mock.Anything).Return(selectedContainerDefinition, nil)
+	// Setup mock calls for selectors
+	mockSel.On("Cluster", mock.Anything).Return(cluster, nil)
+	mockSel.On("Service", mock.Anything, cluster).Return(service, nil)
+	mockSel.On("ContainerDefinition", mock.Anything, service).Return(containerDefinition, nil)
 
 	// Test the function
 	err := runLogs(context.Background(), mockClient, mockSel)
@@ -169,13 +162,10 @@ func TestRunLogs_MissingLogOptions(t *testing.T) {
 		LogConfiguration: logConfiguration,
 	}
 
-	selectedContainerDefinition := &selector.SelectedContainerDefinition{
-		Cluster:             cluster,
-		Service:             service,
-		ContainerDefinition: containerDefinition,
-	}
-
-	mockSel.On("ContainerDefinitionSelector", mock.Anything).Return(selectedContainerDefinition, nil)
+	// Setup mock calls for selectors
+	mockSel.On("Cluster", mock.Anything).Return(cluster, nil)
+	mockSel.On("Service", mock.Anything, cluster).Return(service, nil)
+	mockSel.On("ContainerDefinition", mock.Anything, service).Return(containerDefinition, nil)
 
 	// Test the function
 	err := runLogs(context.Background(), mockClient, mockSel)
@@ -224,15 +214,13 @@ func TestRunLogs_StartLiveTailError(t *testing.T) {
 		LogConfiguration: logConfiguration,
 	}
 
-	selectedContainerDefinition := &selector.SelectedContainerDefinition{
-		Cluster:             cluster,
-		Service:             service,
-		ContainerDefinition: containerDefinition,
-	}
+	// Setup mock calls for selectors
+	mockSel.On("Cluster", mock.Anything).Return(cluster, nil)
+	mockSel.On("Service", mock.Anything, cluster).Return(service, nil)
+	mockSel.On("ContainerDefinition", mock.Anything, service).Return(containerDefinition, nil)
 
 	// Setup StartLiveTail to return an error
 	expectedErr := errors.New("failed to start live tail")
-	mockSel.On("ContainerDefinitionSelector", mock.Anything).Return(selectedContainerDefinition, nil)
 	mockClient.On("StartLiveTail", mock.Anything, "/ecs/my-service", "ecs", mock.AnythingOfType("client.EventHandler")).Return(expectedErr)
 
 	// Test the function
@@ -282,13 +270,10 @@ func TestRunLogs_HandlerBehavior(t *testing.T) {
 		LogConfiguration: logConfiguration,
 	}
 
-	selectedContainerDefinition := &selector.SelectedContainerDefinition{
-		Cluster:             cluster,
-		Service:             service,
-		ContainerDefinition: containerDefinition,
-	}
-
-	mockSel.On("ContainerDefinitionSelector", mock.Anything).Return(selectedContainerDefinition, nil)
+	// Setup mock calls for selectors
+	mockSel.On("Cluster", mock.Anything).Return(cluster, nil)
+	mockSel.On("Service", mock.Anything, cluster).Return(service, nil)
+	mockSel.On("ContainerDefinition", mock.Anything, service).Return(containerDefinition, nil)
 
 	// Capture the handler function
 	var capturedHandler client.EventHandler

--- a/cmd/mocks_test.go
+++ b/cmd/mocks_test.go
@@ -5,7 +5,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/sestrella/iecs/client"
-	"github.com/sestrella/iecs/selector"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -52,8 +51,8 @@ func (m *MockSelectors) Cluster(ctx context.Context) (*types.Cluster, error) {
 	return args.Get(0).(*types.Cluster), args.Error(1)
 }
 
-func (m *MockSelectors) Service(ctx context.Context, clusterArn string) (*types.Service, error) {
-	args := m.Called(ctx, clusterArn)
+func (m *MockSelectors) Service(ctx context.Context, cluster *types.Cluster) (*types.Service, error) {
+	args := m.Called(ctx, cluster)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
@@ -62,18 +61,17 @@ func (m *MockSelectors) Service(ctx context.Context, clusterArn string) (*types.
 
 func (m *MockSelectors) Task(
 	ctx context.Context,
-	clusterArn string,
-	serviceArn string,
+	service *types.Service,
 ) (*types.Task, error) {
-	args := m.Called(ctx, clusterArn, serviceArn)
+	args := m.Called(ctx, service)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
 	return args.Get(0).(*types.Task), args.Error(1)
 }
 
-func (m *MockSelectors) Container(containers []types.Container) (*types.Container, error) {
-	args := m.Called(containers)
+func (m *MockSelectors) Container(ctx context.Context, task *types.Task) (*types.Container, error) {
+	args := m.Called(ctx, task)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
@@ -82,31 +80,11 @@ func (m *MockSelectors) Container(containers []types.Container) (*types.Containe
 
 func (m *MockSelectors) ContainerDefinition(
 	ctx context.Context,
-	taskDefinition string,
+	service *types.Service,
 ) (*types.ContainerDefinition, error) {
-	args := m.Called(ctx, taskDefinition)
+	args := m.Called(ctx, service)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
 	return args.Get(0).(*types.ContainerDefinition), args.Error(1)
-}
-
-func (m *MockSelectors) ContainerSelector(
-	ctx context.Context,
-) (*selector.SelectedContainer, error) {
-	args := m.Called(ctx)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).(*selector.SelectedContainer), args.Error(1)
-}
-
-func (m *MockSelectors) ContainerDefinitionSelector(
-	ctx context.Context,
-) (*selector.SelectedContainerDefinition, error) {
-	args := m.Called(ctx)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).(*selector.SelectedContainerDefinition), args.Error(1)
 }

--- a/selector/root.go
+++ b/selector/root.go
@@ -16,19 +16,6 @@ var (
 	titleStyle           = lipgloss.NewStyle().Bold(true)
 )
 
-type SelectedContainer struct {
-	Cluster   *types.Cluster
-	Service   *types.Service
-	Task      *types.Task
-	Container *types.Container
-}
-
-type SelectedContainerDefinition struct {
-	Cluster             *types.Cluster
-	Service             *types.Service
-	ContainerDefinition *types.ContainerDefinition
-}
-
 type Selectors interface {
 	Cluster(ctx context.Context) (*types.Cluster, error)
 	Service(ctx context.Context, cluster *types.Cluster) (*types.Service, error)
@@ -38,9 +25,6 @@ type Selectors interface {
 		ctx context.Context,
 		service *types.Service,
 	) (*types.ContainerDefinition, error)
-
-	ContainerSelector(ctx context.Context) (*SelectedContainer, error)
-	ContainerDefinitionSelector(ctx context.Context) (*SelectedContainerDefinition, error)
 }
 
 type ClientSelectors struct {
@@ -49,62 +33,6 @@ type ClientSelectors struct {
 
 func NewSelectors(client *ecs.Client) Selectors {
 	return ClientSelectors{client: client}
-}
-
-func (cs ClientSelectors) ContainerSelector(
-	ctx context.Context,
-) (*SelectedContainer, error) {
-	cluster, err := cs.Cluster(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	service, err := cs.Service(ctx, cluster)
-	if err != nil {
-		return nil, err
-	}
-
-	task, err := cs.Task(ctx, service)
-	if err != nil {
-		return nil, err
-	}
-
-	container, err := cs.Container(ctx, task)
-	if err != nil {
-		return nil, err
-	}
-
-	return &SelectedContainer{
-		Cluster:   cluster,
-		Service:   service,
-		Task:      task,
-		Container: container,
-	}, nil
-}
-
-func (cs ClientSelectors) ContainerDefinitionSelector(
-	ctx context.Context,
-) (*SelectedContainerDefinition, error) {
-	cluster, err := cs.Cluster(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	service, err := cs.Service(ctx, cluster)
-	if err != nil {
-		return nil, err
-	}
-
-	containerDefinition, err := cs.ContainerDefinition(ctx, service)
-	if err != nil {
-		return nil, err
-	}
-
-	return &SelectedContainerDefinition{
-		Cluster:             cluster,
-		Service:             service,
-		ContainerDefinition: containerDefinition,
-	}, nil
 }
 
 func (cs ClientSelectors) Cluster(ctx context.Context) (*types.Cluster, error) {


### PR DESCRIPTION
This pull request refactors the container and container definition selection logic in the `exec` and `logs` commands by replacing monolithic selector methods with more granular, step-by-step selection methods. It also updates the corresponding test cases and mock implementations to align with the new approach.

### Refactoring of Selection Logic:

* **`cmd/exec.go`**: Replaced the `ContainerSelector` method with a new `containerSelector` function that sequentially selects a cluster, service, task, and container. Introduced a `SelectedContainer` struct to encapsulate these components. [[1]](diffhunk://#diff-ce92eefe0908ac93cdc54bd33b7d01c347c159ae09a9324bd0479acdbc38c442R28-R34) [[2]](diffhunk://#diff-ce92eefe0908ac93cdc54bd33b7d01c347c159ae09a9324bd0479acdbc38c442R158-R189)

* **`cmd/logs.go`**: Replaced the `ContainerDefinitionSelector` method with a new `containerDefinitionSelector` function that sequentially selects a cluster, service, and container definition. Introduced a `SelectedContainerDefinition` struct to encapsulate these components. [[1]](diffhunk://#diff-e6824e1936e82569dca8cc8a16f0b68ec37bfd4c057700032fb0587747c2373fL43-R83) [[2]](diffhunk://#diff-e6824e1936e82569dca8cc8a16f0b68ec37bfd4c057700032fb0587747c2373fR102-R127)

### Updates to Test Cases:

* **`cmd/exec_test.go`**: Updated tests to mock individual selector methods (`Cluster`, `Service`, `Task`, `Container`) instead of the removed `ContainerSelector` method. Adjusted error scenarios to reflect the new method breakdown. [[1]](diffhunk://#diff-aff0e0c712b3e4933b31c0f3d59278bf6aa67633dafd55a6d82b79e11dc98764L57-R60) [[2]](diffhunk://#diff-aff0e0c712b3e4933b31c0f3d59278bf6aa67633dafd55a6d82b79e11dc98764L112-R109) [[3]](diffhunk://#diff-aff0e0c712b3e4933b31c0f3d59278bf6aa67633dafd55a6d82b79e11dc98764R220-R227)

* **`cmd/logs_test.go`**: Updated tests to mock individual selector methods (`Cluster`, `Service`, `ContainerDefinition`) instead of the removed `ContainerDefinitionSelector` method. Adjusted error scenarios and log configuration validations accordingly. [[1]](diffhunk://#diff-22e518acf530a844ab4051bf614550b8ebfca84040fb558fab1c4fc3c2b0fed8L54-R56) [[2]](diffhunk://#diff-22e518acf530a844ab4051bf614550b8ebfca84040fb558fab1c4fc3c2b0fed8L77-R75) [[3]](diffhunk://#diff-22e518acf530a844ab4051bf614550b8ebfca84040fb558fab1c4fc3c2b0fed8L227-L235)

### Mock and Interface Adjustments:

* **`cmd/mocks_test.go`**: Removed the `ContainerSelector` and `ContainerDefinitionSelector` mock methods. Added mocks for the new granular selector methods (`Cluster`, `Service`, `Task`, `Container`, `ContainerDefinition`). Updated existing mock methods to use structured types instead of raw strings for parameters like `cluster` and `service`. [[1]](diffhunk://#diff-9d245e810313ea069510f7ac20f26d962068f8588e033b2c56b2f1c63b65a8baL55-R55) [[2]](diffhunk://#diff-9d245e810313ea069510f7ac20f26d962068f8588e033b2c56b2f1c63b65a8baL85-L112)

* **`selector/root.go`**: Removed the `SelectedContainer` and `SelectedContainerDefinition` structs and their associated methods from the `Selectors` interface. Added granular methods for selecting individual components (`Cluster`, `Service`, `Task`, etc.).