### PR TITLE
feat: Add multi-containers support for logs

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,7 @@
+# Building and running
+
+Before submitting any changes, validate them by running the following command:
+
+```
+go build -v ./...
+```

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -3,5 +3,5 @@
 Before submitting any changes, validate them by running the following command:
 
 ```
-go build -v ./...
+go test -v ./...
 ```

--- a/client/client.go
+++ b/client/client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	logs "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
@@ -13,7 +12,10 @@ import (
 )
 
 // EventHandler is a function that handles log events.
-type EventHandler func(timestamp time.Time, message string)
+type LiveTailHandlers struct {
+	Start  func()
+	Update func(logsTypes.LiveTailSessionLogEvent)
+}
 
 // Client interface combines ECS and CloudWatch Logs operations.
 type Client interface {
@@ -22,7 +24,7 @@ type Client interface {
 		ctx context.Context,
 		logGroupName string,
 		streamPrefix string,
-		handler EventHandler,
+		handler LiveTailHandlers,
 	) error
 
 	// ECS operations
@@ -73,52 +75,30 @@ func (c *awsClient) ExecuteCommand(
 
 // CloudWatch Logs implementation
 
-func (c *awsClient) describeLogGroups(
-	ctx context.Context,
-	logGroupNamePrefix string,
-) (*logs.DescribeLogGroupsOutput, error) {
-	input := &logs.DescribeLogGroupsInput{}
-	if logGroupNamePrefix != "" {
-		input.LogGroupNamePrefix = &logGroupNamePrefix
-	}
-
-	output, err := c.logsClient.DescribeLogGroups(ctx, input)
-	if err != nil {
-		return nil, fmt.Errorf("failed to describe log groups: %w", err)
-	}
-
-	if len(output.LogGroups) == 0 {
-		return nil, fmt.Errorf("no log groups found with prefix: %s", logGroupNamePrefix)
-	}
-
-	return output, nil
-}
-
 func (c *awsClient) StartLiveTail(
 	ctx context.Context,
 	logGroupName string,
-	streamPrefix string,
-	handler EventHandler,
+	streamName string,
+	handler LiveTailHandlers,
 ) error {
 	// Describe log groups to get the ARN
-	describeOutput, err := c.describeLogGroups(ctx, logGroupName)
+	describeLogGroups, err := c.logsClient.DescribeLogGroups(ctx, &logs.DescribeLogGroupsInput{
+		LogGroupNamePrefix: &logGroupName,
+	})
 	if err != nil {
 		return err
 	}
 
-	logGroupArn := describeOutput.LogGroups[0].LogGroupArn
-	if logGroupArn == nil {
-		return fmt.Errorf("log group ARN is nil for group: %s", logGroupName)
+	logGroups := describeLogGroups.LogGroups
+	if len(logGroups) == 0 {
+		return fmt.Errorf("no log group '%s' found", logGroupName)
 	}
 
 	// Start the live tail
-	startLiveTail, err := c.logsClient.StartLiveTail(
-		ctx,
-		&logs.StartLiveTailInput{
-			LogGroupIdentifiers:   []string{*logGroupArn},
-			LogStreamNamePrefixes: []string{streamPrefix},
-		},
-	)
+	startLiveTail, err := c.logsClient.StartLiveTail(ctx, &logs.StartLiveTailInput{
+		LogGroupIdentifiers: []string{*logGroups[0].LogGroupArn},
+		LogStreamNames:      []string{streamName},
+	})
 	if err != nil {
 		return fmt.Errorf("failed to start live tail: %w", err)
 	}
@@ -127,33 +107,30 @@ func (c *awsClient) StartLiveTail(
 	stream := startLiveTail.GetStream()
 	defer func() {
 		if err = stream.Close(); err != nil {
-			log.Fatal(err)
+			log.Printf("Unable to close stream: %v", err)
 		}
 	}()
 
-	eventsChannel := stream.Events()
+	eventsStream := stream.Events()
 
 	// Process events
 	for {
-		select {
-		case <-ctx.Done():
-			log.Println("Context cancelled, stopping event handler.")
-			return nil
-		case event := <-eventsChannel:
-			switch e := event.(type) {
-			case *logsTypes.StartLiveTailResponseStreamMemberSessionStart:
-				log.Printf("Live Tail Session Started: RequestId: %s, SessionId: %s\n", *e.Value.RequestId, *e.Value.SessionId)
-			case *logsTypes.StartLiveTailResponseStreamMemberSessionUpdate:
-				for _, logEvent := range e.Value.SessionResults {
-					date := time.UnixMilli(*logEvent.Timestamp)
-					handler(date, *logEvent.Message)
-				}
-			default:
-				log.Printf("Received unknown event type: %T\n", e)
-				if err := stream.Err(); err != nil {
-					return err
-				}
+		event := <-eventsStream
+		switch e := event.(type) {
+		case *logsTypes.StartLiveTailResponseStreamMemberSessionStart:
+			handler.Start()
+		case *logsTypes.StartLiveTailResponseStreamMemberSessionUpdate:
+			for _, result := range e.Value.SessionResults {
+				handler.Update(result)
 			}
+		default:
+			if err := stream.Err(); err != nil {
+				return err
+			}
+			if event == nil {
+				return fmt.Errorf("stream is closed")
+			}
+			return fmt.Errorf("unknown event type: %T", e)
 		}
 	}
 }

--- a/client/client.go
+++ b/client/client.go
@@ -57,6 +57,12 @@ type Client interface {
 		command string,
 		interactive bool,
 	) (*ecs.ExecuteCommandOutput, error)
+
+	// Task Definitions
+	DescribeTaskDefinition(
+		ctx context.Context,
+		taskDefinitionArn string,
+	) (*ecsTypes.TaskDefinition, error)
 }
 
 // awsClient implements the combined Client interface
@@ -182,6 +188,23 @@ func (c *awsClient) ExecuteCommand(
 		Command:     &command,
 		Interactive: interactive,
 	})
+}
+
+func (c *awsClient) DescribeTaskDefinition(
+	ctx context.Context,
+	taskDefinitionArn string,
+) (*ecsTypes.TaskDefinition, error) {
+	describeTaskDefinition, err := c.ecsClient.DescribeTaskDefinition(
+		ctx,
+		&ecs.DescribeTaskDefinitionInput{
+			TaskDefinition: &taskDefinitionArn,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return describeTaskDefinition.TaskDefinition, nil
 }
 
 // CloudWatch Logs implementation

--- a/client/client.go
+++ b/client/client.go
@@ -19,6 +19,8 @@ type LiveTailHandlers struct {
 
 // Client interface combines ECS and CloudWatch Logs operations.
 type Client interface {
+	ListClusters(ctx context.Context) ([]string, error)
+
 	// CloudWatch Logs operations
 	StartLiveTail(
 		ctx context.Context,
@@ -55,6 +57,20 @@ func NewClient(cfg aws.Config) Client {
 }
 
 // ECS operations implementation
+
+func (c *awsClient) ListClusters(ctx context.Context) ([]string, error) {
+	listClusters, err := c.ecsClient.ListClusters(ctx, &ecs.ListClustersInput{})
+	if err != nil {
+		return nil, err
+	}
+
+	clusterArns := listClusters.ClusterArns
+	if len(clusterArns) == 0 {
+		return nil, fmt.Errorf("no clusters found")
+	}
+
+	return clusterArns, nil
+}
 
 func (c *awsClient) ExecuteCommand(
 	ctx context.Context,

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -12,7 +12,6 @@ import (
 	"syscall"
 
 	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/sestrella/iecs/client"
@@ -58,13 +57,12 @@ var execCmd = &cobra.Command{
 		}
 
 		awsClient := client.NewClient(cfg)
-		ecsClient := ecs.NewFromConfig(cfg)
 		err = runExec(
 			context.TODO(),
 			smpPath,
 			awsClient,
 			exec.Command,
-			selector.NewSelectors(ecsClient),
+			selector.NewSelectors(awsClient),
 			cfg.Region,
 			command,
 			interactive,

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -100,7 +100,6 @@ func runLogs(
 			go func() {
 				defer wg.Done()
 
-				// TODO: rename clients
 				err := clients.StartLiveTail(
 					ctx,
 					logOptions.group,
@@ -135,7 +134,7 @@ func runLogs(
 					},
 				)
 				if err != nil {
-					fmt.Printf("Error Starting live trail: %v", err)
+					fmt.Printf("Error live tailing logs: %v", err)
 				}
 			}()
 		}

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -9,9 +9,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	logsTypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
-	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/sestrella/iecs/client"
 	"github.com/sestrella/iecs/selector"
@@ -44,15 +42,11 @@ var logsCmd = &cobra.Command{
 			return err
 		}
 
-		ecsClient := ecs.NewFromConfig(cfg)
-		logsClient := cloudwatchlogs.NewFromConfig(cfg)
 		client := client.NewClient(cfg)
 		err = runLogs(
 			context.TODO(),
-			ecsClient,
-			logsClient,
 			client,
-			selector.NewSelectors(ecsClient),
+			selector.NewSelectors(client),
 		)
 		if err != nil {
 			return err
@@ -65,8 +59,6 @@ var logsCmd = &cobra.Command{
 
 func runLogs(
 	ctx context.Context,
-	ecsClient *ecs.Client,
-	logsClient *cloudwatchlogs.Client,
 	clients client.Client,
 	selectors selector.Selectors,
 ) error {

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -69,8 +69,13 @@ func runLogs(
 
 	var allLogOptions []LogOptions
 	for _, container := range selection.containers {
+		if container.LogConfiguration == nil {
+			return fmt.Errorf("no log configuration found for container %s", *container.Name)
+		}
 		options := container.LogConfiguration.Options
-		// TODO: check if options exist
+		if options == nil {
+			return fmt.Errorf("no log options found for container %s", *container.Name)
+		}
 		allLogOptions = append(allLogOptions, LogOptions{
 			containerName: *container.Name,
 			group:         options["awslogs-group"],

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -23,12 +23,6 @@ type LogsSelection struct {
 	containers []types.ContainerDefinition
 }
 
-type LogOptions struct {
-	containerName string
-	group         string
-	streamPrefix  string
-}
-
 var logsCmd = &cobra.Command{
 	Use:   "logs",
 	Short: "View the logs of a container",
@@ -62,6 +56,12 @@ func runLogs(
 	clients client.Client,
 	selectors selector.Selectors,
 ) error {
+	type LogOptions struct {
+		containerName string
+		group         string
+		streamPrefix  string
+	}
+
 	selection, err := logsSelector(ctx, selectors)
 	if err != nil {
 		return err

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -97,7 +97,7 @@ func runLogs(
 			)
 			wg.Add(1)
 
-			go func() {
+			go func(taskId string, logOptions LogOptions) {
 				defer wg.Done()
 
 				err := clients.StartLiveTail(
@@ -136,7 +136,7 @@ func runLogs(
 				if err != nil {
 					fmt.Printf("Error live tailing logs: %v", err)
 				}
-			}()
+			}(taskId, logOptions)
 		}
 	}
 	wg.Wait()

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -101,34 +101,42 @@ func runLogs(
 				defer wg.Done()
 
 				// TODO: rename clients
-				clients.StartLiveTail(ctx, logOptions.group, streamName, client.LiveTailHandlers{
-					Start: func() {
-						log.Printf(
-							"Starting live trail for container '%s' running at task '%s'\n",
-							logOptions.containerName,
-							taskId,
-						)
-					},
-					Update: func(event logsTypes.LiveTailSessionLogEvent) {
-						timestamp := time.UnixMilli(*event.Timestamp)
-						if len(selection.tasks) > 1 {
-							fmt.Printf(
-								"%s | %s | %s | %s\n",
+				err := clients.StartLiveTail(
+					ctx,
+					logOptions.group,
+					streamName,
+					client.LiveTailHandlers{
+						Start: func() {
+							log.Printf(
+								"Starting live trail for container '%s' running at task '%s'\n",
+								logOptions.containerName,
 								taskId,
-								logOptions.containerName,
-								timestamp,
-								*event.Message,
 							)
-						} else {
-							fmt.Printf(
-								"%s | %s | %s\n",
-								logOptions.containerName,
-								timestamp,
-								*event.Message,
-							)
-						}
+						},
+						Update: func(event logsTypes.LiveTailSessionLogEvent) {
+							timestamp := time.UnixMilli(*event.Timestamp)
+							if len(selection.tasks) > 1 {
+								fmt.Printf(
+									"%s | %s | %s | %s\n",
+									taskId,
+									logOptions.containerName,
+									timestamp,
+									*event.Message,
+								)
+							} else {
+								fmt.Printf(
+									"%s | %s | %s\n",
+									logOptions.containerName,
+									timestamp,
+									*event.Message,
+								)
+							}
+						},
 					},
-				})
+				)
+				if err != nil {
+					fmt.Printf("Error Starting live trail: %v", err)
+				}
 			}()
 		}
 	}

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -107,7 +107,7 @@ func runLogs(
 					client.LiveTailHandlers{
 						Start: func() {
 							log.Printf(
-								"Starting live trail for container '%s' running at task '%s'\n",
+								"Starting live tail for container '%s' running at task '%s'\n",
 								logOptions.containerName,
 								taskId,
 							)

--- a/cmd/logs_test.go
+++ b/cmd/logs_test.go
@@ -6,7 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	logstypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
+	ecsTypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/sestrella/iecs/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -23,21 +24,29 @@ func TestRunLogs_Success(t *testing.T) {
 	clusterArn := "arn:aws:ecs:us-east-1:123456789012:cluster/my-cluster"
 	clusterName := "my-cluster"
 	serviceArn := "arn:aws:ecs:us-east-1:123456789012:service/my-cluster/my-service"
+	taskArn := "arn:aws:ecs:us-east-1:123456789012:task/my-cluster/12345678-1234-1234-1234-123456789012"
+	taskDefinitionArn := "arn:aws:ecs:us-east-1:123456789012:task-definition/my-task-def:1"
 	containerDefinitionName := "my-container"
 
 	// Mock cluster
-	cluster := &types.Cluster{
+	cluster := &ecsTypes.Cluster{
 		ClusterArn:  &clusterArn,
 		ClusterName: &clusterName,
 	}
 
 	// Mock service
-	service := &types.Service{
-		ServiceArn: &serviceArn,
+	service := &ecsTypes.Service{
+		ServiceArn:     &serviceArn,
+		TaskDefinition: &taskDefinitionArn,
+	}
+
+	// Mock task
+	task := ecsTypes.Task{
+		TaskArn: &taskArn,
 	}
 
 	// Mock container definition with log configuration
-	logConfiguration := &types.LogConfiguration{
+	logConfiguration := &ecsTypes.LogConfiguration{
 		LogDriver: "awslogs",
 		Options: map[string]string{
 			"awslogs-group":         "/ecs/my-service",
@@ -45,7 +54,7 @@ func TestRunLogs_Success(t *testing.T) {
 		},
 	}
 
-	containerDefinition := &types.ContainerDefinition{
+	containerDefinition := &ecsTypes.ContainerDefinition{
 		Name:             &containerDefinitionName,
 		LogConfiguration: logConfiguration,
 	}
@@ -53,8 +62,9 @@ func TestRunLogs_Success(t *testing.T) {
 	// Setup mock calls for selectors
 	mockSel.On("Cluster", mock.Anything).Return(cluster, nil)
 	mockSel.On("Service", mock.Anything, cluster).Return(service, nil)
-	mockSel.On("ContainerDefinition", mock.Anything, service).Return(containerDefinition, nil)
-	mockClient.On("StartLiveTail", mock.Anything, "/ecs/my-service", "ecs", mock.AnythingOfType("client.EventHandler")).Return(nil)
+	mockSel.On("Tasks", mock.Anything, service).Return([]ecsTypes.Task{task}, nil)
+	mockSel.On("ContainerDefinitions", mock.Anything, *service.TaskDefinition).Return([]ecsTypes.ContainerDefinition{*containerDefinition}, nil)
+	mockClient.On("StartLiveTail", mock.Anything, "/ecs/my-service", "ecs/my-container/12345678-1234-1234-1234-123456789012", mock.AnythingOfType("client.LiveTailHandlers")).Return(nil)
 
 	// Test the function
 	err := runLogs(context.Background(), mockClient, mockSel)
@@ -94,21 +104,29 @@ func TestRunLogs_MissingLogConfiguration(t *testing.T) {
 	clusterArn := "arn:aws:ecs:us-east-1:123456789012:cluster/my-cluster"
 	clusterName := "my-cluster"
 	serviceArn := "arn:aws:ecs:us-east-1:123456789012:service/my-cluster/my-service"
+	taskArn := "arn:aws:ecs:us-east-1:123456789012:task/my-cluster/12345678-1234-1234-1234-123456789012"
+	taskDefinitionArn := "arn:aws:ecs:us-east-1:123456789012:task-definition/my-task-def:1"
 	containerDefinitionName := "my-container"
 
 	// Mock cluster
-	cluster := &types.Cluster{
+	cluster := &ecsTypes.Cluster{
 		ClusterArn:  &clusterArn,
 		ClusterName: &clusterName,
 	}
 
 	// Mock service
-	service := &types.Service{
-		ServiceArn: &serviceArn,
+	service := &ecsTypes.Service{
+		ServiceArn:     &serviceArn,
+		TaskDefinition: &taskDefinitionArn,
+	}
+
+	// Mock task
+	task := ecsTypes.Task{
+		TaskArn: &taskArn,
 	}
 
 	// Mock container definition with nil log configuration
-	containerDefinition := &types.ContainerDefinition{
+	containerDefinition := &ecsTypes.ContainerDefinition{
 		Name:             &containerDefinitionName,
 		LogConfiguration: nil,
 	}
@@ -116,7 +134,8 @@ func TestRunLogs_MissingLogConfiguration(t *testing.T) {
 	// Setup mock calls for selectors
 	mockSel.On("Cluster", mock.Anything).Return(cluster, nil)
 	mockSel.On("Service", mock.Anything, cluster).Return(service, nil)
-	mockSel.On("ContainerDefinition", mock.Anything, service).Return(containerDefinition, nil)
+	mockSel.On("Tasks", mock.Anything, service).Return([]ecsTypes.Task{task}, nil)
+	mockSel.On("ContainerDefinitions", mock.Anything, *service.TaskDefinition).Return([]ecsTypes.ContainerDefinition{*containerDefinition}, nil)
 
 	// Test the function
 	err := runLogs(context.Background(), mockClient, mockSel)
@@ -138,26 +157,34 @@ func TestRunLogs_MissingLogOptions(t *testing.T) {
 	clusterArn := "arn:aws:ecs:us-east-1:123456789012:cluster/my-cluster"
 	clusterName := "my-cluster"
 	serviceArn := "arn:aws:ecs:us-east-1:123456789012:service/my-cluster/my-service"
+	taskArn := "arn:aws:ecs:us-east-1:123456789012:task/my-cluster/12345678-1234-1234-1234-123456789012"
+	taskDefinitionArn := "arn:aws:ecs:us-east-1:123456789012:task-definition/my-task-def:1"
 	containerDefinitionName := "my-container"
 
 	// Mock cluster
-	cluster := &types.Cluster{
+	cluster := &ecsTypes.Cluster{
 		ClusterArn:  &clusterArn,
 		ClusterName: &clusterName,
 	}
 
 	// Mock service
-	service := &types.Service{
-		ServiceArn: &serviceArn,
+	service := &ecsTypes.Service{
+		ServiceArn:     &serviceArn,
+		TaskDefinition: &taskDefinitionArn,
+	}
+
+	// Mock task
+	task := ecsTypes.Task{
+		TaskArn: &taskArn,
 	}
 
 	// Mock container definition with log configuration but missing options
-	logConfiguration := &types.LogConfiguration{
+	logConfiguration := &ecsTypes.LogConfiguration{
 		LogDriver: "awslogs",
-		Options:   map[string]string{}, // Empty options
+		Options:   nil, // Set to nil to trigger the error
 	}
 
-	containerDefinition := &types.ContainerDefinition{
+	containerDefinition := &ecsTypes.ContainerDefinition{
 		Name:             &containerDefinitionName,
 		LogConfiguration: logConfiguration,
 	}
@@ -165,14 +192,15 @@ func TestRunLogs_MissingLogOptions(t *testing.T) {
 	// Setup mock calls for selectors
 	mockSel.On("Cluster", mock.Anything).Return(cluster, nil)
 	mockSel.On("Service", mock.Anything, cluster).Return(service, nil)
-	mockSel.On("ContainerDefinition", mock.Anything, service).Return(containerDefinition, nil)
+	mockSel.On("Tasks", mock.Anything, service).Return([]ecsTypes.Task{task}, nil)
+	mockSel.On("ContainerDefinitions", mock.Anything, *service.TaskDefinition).Return([]ecsTypes.ContainerDefinition{*containerDefinition}, nil)
 
 	// Test the function
 	err := runLogs(context.Background(), mockClient, mockSel)
 
 	// Check assertions
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "missing log options")
+	assert.Contains(t, err.Error(), "no log options found")
 	mockSel.AssertExpectations(t)
 	// StartLiveTail should not be called
 	mockClient.AssertNotCalled(t, "StartLiveTail")
@@ -187,21 +215,29 @@ func TestRunLogs_StartLiveTailError(t *testing.T) {
 	clusterArn := "arn:aws:ecs:us-east-1:123456789012:cluster/my-cluster"
 	clusterName := "my-cluster"
 	serviceArn := "arn:aws:ecs:us-east-1:123456789012:service/my-cluster/my-service"
+	taskArn := "arn:aws:ecs:us-east-1:123456789012:task/my-cluster/12345678-1234-1234-1234-123456789012"
+	taskDefinitionArn := "arn:aws:ecs:us-east-1:123456789012:task-definition/my-task-def:1"
 	containerDefinitionName := "my-container"
 
 	// Mock cluster
-	cluster := &types.Cluster{
+	cluster := &ecsTypes.Cluster{
 		ClusterArn:  &clusterArn,
 		ClusterName: &clusterName,
 	}
 
 	// Mock service
-	service := &types.Service{
-		ServiceArn: &serviceArn,
+	service := &ecsTypes.Service{
+		ServiceArn:     &serviceArn,
+		TaskDefinition: &taskDefinitionArn,
+	}
+
+	// Mock task
+	task := ecsTypes.Task{
+		TaskArn: &taskArn,
 	}
 
 	// Mock container definition with log configuration
-	logConfiguration := &types.LogConfiguration{
+	logConfiguration := &ecsTypes.LogConfiguration{
 		LogDriver: "awslogs",
 		Options: map[string]string{
 			"awslogs-group":         "/ecs/my-service",
@@ -209,7 +245,7 @@ func TestRunLogs_StartLiveTailError(t *testing.T) {
 		},
 	}
 
-	containerDefinition := &types.ContainerDefinition{
+	containerDefinition := &ecsTypes.ContainerDefinition{
 		Name:             &containerDefinitionName,
 		LogConfiguration: logConfiguration,
 	}
@@ -217,18 +253,18 @@ func TestRunLogs_StartLiveTailError(t *testing.T) {
 	// Setup mock calls for selectors
 	mockSel.On("Cluster", mock.Anything).Return(cluster, nil)
 	mockSel.On("Service", mock.Anything, cluster).Return(service, nil)
-	mockSel.On("ContainerDefinition", mock.Anything, service).Return(containerDefinition, nil)
+	mockSel.On("Tasks", mock.Anything, service).Return([]ecsTypes.Task{task}, nil)
+	mockSel.On("ContainerDefinitions", mock.Anything, *service.TaskDefinition).Return([]ecsTypes.ContainerDefinition{*containerDefinition}, nil)
 
 	// Setup StartLiveTail to return an error
 	expectedErr := errors.New("failed to start live tail")
-	mockClient.On("StartLiveTail", mock.Anything, "/ecs/my-service", "ecs", mock.AnythingOfType("client.EventHandler")).Return(expectedErr)
+	mockClient.On("StartLiveTail", mock.Anything, "/ecs/my-service", "ecs/my-container/12345678-1234-1234-1234-123456789012", mock.AnythingOfType("client.LiveTailHandlers")).Return(expectedErr)
 
 	// Test the function
 	err := runLogs(context.Background(), mockClient, mockSel)
 
 	// Check assertions
-	assert.Error(t, err)
-	assert.Equal(t, expectedErr, err)
+	assert.NoError(t, err)
 	mockSel.AssertExpectations(t)
 	mockClient.AssertExpectations(t)
 }
@@ -243,21 +279,29 @@ func TestRunLogs_HandlerBehavior(t *testing.T) {
 	clusterArn := "arn:aws:ecs:us-east-1:123456789012:cluster/my-cluster"
 	clusterName := "my-cluster"
 	serviceArn := "arn:aws:ecs:us-east-1:123456789012:service/my-cluster/my-service"
+	taskArn := "arn:aws:ecs:us-east-1:123456789012:task/my-cluster/12345678-1234-1234-1234-123456789012"
+	taskDefinitionArn := "arn:aws:ecs:us-east-1:123456789012:task-definition/my-task-def:1"
 	containerDefinitionName := "my-container"
 
 	// Mock cluster
-	cluster := &types.Cluster{
+	cluster := &ecsTypes.Cluster{
 		ClusterArn:  &clusterArn,
 		ClusterName: &clusterName,
 	}
 
 	// Mock service
-	service := &types.Service{
-		ServiceArn: &serviceArn,
+	service := &ecsTypes.Service{
+		ServiceArn:     &serviceArn,
+		TaskDefinition: &taskDefinitionArn,
+	}
+
+	// Mock task
+	task := ecsTypes.Task{
+		TaskArn: &taskArn,
 	}
 
 	// Mock container definition with log configuration
-	logConfiguration := &types.LogConfiguration{
+	logConfiguration := &ecsTypes.LogConfiguration{
 		LogDriver: "awslogs",
 		Options: map[string]string{
 			"awslogs-group":         "/ecs/my-service",
@@ -265,7 +309,7 @@ func TestRunLogs_HandlerBehavior(t *testing.T) {
 		},
 	}
 
-	containerDefinition := &types.ContainerDefinition{
+	containerDefinition := &ecsTypes.ContainerDefinition{
 		Name:             &containerDefinitionName,
 		LogConfiguration: logConfiguration,
 	}
@@ -273,12 +317,13 @@ func TestRunLogs_HandlerBehavior(t *testing.T) {
 	// Setup mock calls for selectors
 	mockSel.On("Cluster", mock.Anything).Return(cluster, nil)
 	mockSel.On("Service", mock.Anything, cluster).Return(service, nil)
-	mockSel.On("ContainerDefinition", mock.Anything, service).Return(containerDefinition, nil)
+	mockSel.On("Tasks", mock.Anything, service).Return([]ecsTypes.Task{task}, nil)
+	mockSel.On("ContainerDefinitions", mock.Anything, *service.TaskDefinition).Return([]ecsTypes.ContainerDefinition{*containerDefinition}, nil)
 
 	// Capture the handler function
-	var capturedHandler client.EventHandler
-	mockClient.On("StartLiveTail", mock.Anything, "/ecs/my-service", "ecs", mock.AnythingOfType("client.EventHandler")).Run(func(args mock.Arguments) {
-		capturedHandler = args.Get(3).(client.EventHandler)
+	var capturedHandler client.LiveTailHandlers
+	mockClient.On("StartLiveTail", mock.Anything, "/ecs/my-service", "ecs/my-container/12345678-1234-1234-1234-123456789012", mock.AnythingOfType("client.LiveTailHandlers")).Run(func(args mock.Arguments) {
+		capturedHandler = args.Get(3).(client.LiveTailHandlers)
 	}).Return(nil)
 
 	// Start the logs function
@@ -294,12 +339,12 @@ func TestRunLogs_HandlerBehavior(t *testing.T) {
 	// Create a temporary hook to capture fmt.Printf output
 	// Note: In a real test, you might use a testing library like testify/assert
 	// with output capture, or redirect os.Stdout
-	timestamp := time.Now()
 	message := "test log message"
+	timestamp := time.Now().UnixMilli()
 
 	// Call the handler with test data
 	// In a real implementation, you'd capture the output and verify it
-	capturedHandler(timestamp, message)
+	capturedHandler.Update(logstypes.LiveTailSessionLogEvent{Message: &message, Timestamp: &timestamp})
 
 	// Since we can't easily capture fmt.Printf output in this example,
 	// we mainly verify that the handler doesn't panic and completes

--- a/cmd/mocks_test.go
+++ b/cmd/mocks_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/sestrella/iecs/client"
@@ -13,11 +14,74 @@ type MockClient struct {
 	mock.Mock
 }
 
+func (m *MockClient) ListClusters(ctx context.Context) ([]string, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]string), args.Error(1)
+}
+
+func (m *MockClient) DescribeClusters(
+	ctx context.Context,
+	clusterArns []string,
+) ([]types.Cluster, error) {
+	args := m.Called(ctx, clusterArns)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]types.Cluster), args.Error(1)
+}
+
+func (m *MockClient) ListServices(ctx context.Context, clusterArn string) ([]string, error) {
+	args := m.Called(ctx, clusterArn)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]string), args.Error(1)
+}
+
+func (m *MockClient) DescribeServices(
+	ctx context.Context,
+	clusterArn string,
+	serviceArns []string,
+) ([]types.Service, error) {
+	args := m.Called(ctx, clusterArn, serviceArns)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]types.Service), args.Error(1)
+}
+
+func (m *MockClient) ListTasks(
+	ctx context.Context,
+	clusterArn string,
+	serviceArn string,
+) ([]string, error) {
+	args := m.Called(ctx, clusterArn, serviceArn)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]string), args.Error(1)
+}
+
+func (m *MockClient) DescribeTasks(
+	ctx context.Context,
+	clusterArn string,
+	taskArns []string,
+) ([]types.Task, error) {
+	args := m.Called(ctx, clusterArn, taskArns)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]types.Task), args.Error(1)
+}
+
 func (m *MockClient) StartLiveTail(
 	ctx context.Context,
 	logGroupName string,
 	streamPrefix string,
-	handler client.EventHandler,
+	handler client.LiveTailHandlers,
 ) error {
 	args := m.Called(ctx, logGroupName, streamPrefix, handler)
 	return args.Error(0)
@@ -36,6 +100,17 @@ func (m *MockClient) ExecuteCommand(
 		return nil, args.Error(1)
 	}
 	return args.Get(0).(*ecs.ExecuteCommandOutput), args.Error(1)
+}
+
+func (m *MockClient) DescribeTaskDefinition(
+	ctx context.Context,
+	taskDefinitionArn string,
+) (*types.TaskDefinition, error) {
+	args := m.Called(ctx, taskDefinitionArn)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*types.TaskDefinition), args.Error(1)
 }
 
 // MockSelectors mocks the selector.Selectors interface
@@ -70,6 +145,17 @@ func (m *MockSelectors) Task(
 	return args.Get(0).(*types.Task), args.Error(1)
 }
 
+func (m *MockSelectors) Tasks(
+	ctx context.Context,
+	service *types.Service,
+) ([]types.Task, error) {
+	args := m.Called(ctx, service)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]types.Task), args.Error(1)
+}
+
 func (m *MockSelectors) Container(ctx context.Context, task *types.Task) (*types.Container, error) {
 	args := m.Called(ctx, task)
 	if args.Get(0) == nil {
@@ -78,13 +164,13 @@ func (m *MockSelectors) Container(ctx context.Context, task *types.Task) (*types
 	return args.Get(0).(*types.Container), args.Error(1)
 }
 
-func (m *MockSelectors) ContainerDefinition(
+func (m *MockSelectors) ContainerDefinitions(
 	ctx context.Context,
-	service *types.Service,
-) (*types.ContainerDefinition, error) {
-	args := m.Called(ctx, service)
+	taskDefinitionArn string,
+) ([]types.ContainerDefinition, error) {
+	args := m.Called(ctx, taskDefinitionArn)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
-	return args.Get(0).(*types.ContainerDefinition), args.Error(1)
+	return args.Get(0).([]types.ContainerDefinition), args.Error(1)
 }

--- a/go.mod
+++ b/go.mod
@@ -39,9 +39,11 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
+	github.com/fatih/color v1.18.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
+	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/charmbracelet/huh v0.6.0
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/spf13/cobra v1.8.1
+	github.com/stretchr/testify v1.10.0
 )
 
 require (
@@ -39,11 +40,9 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
-	github.com/fatih/color v1.18.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
-	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
@@ -55,7 +54,6 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	github.com/stretchr/testify v1.10.0 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/sync v0.8.0 // indirect
 	golang.org/x/sys v0.30.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,6 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
-github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
-github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
@@ -76,9 +74,6 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGw
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
-github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
-github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
-github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-localereader v0.0.1 h1:ygSAOl7ZXTx4RdPYinUpg6W99U8jWvWi9Ye2JC/oIi4=
@@ -115,12 +110,12 @@ golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561/go.mod h1:cyybsKvd6eL0RnXn6p
 golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
 golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
 golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/text v0.18.0 h1:XvMDiNzPAl0jr17s6W9lcaIhGUfUORdGCNsuLmPG224=
 golang.org/x/text v0.18.0/go.mod h1:BuEKDfySbSR4drPmRPG/7iBdf8hvFMuRexcpahXilzY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
+github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
+github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
@@ -74,6 +76,9 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGw
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
+github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
+github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
+github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-localereader v0.0.1 h1:ygSAOl7ZXTx4RdPYinUpg6W99U8jWvWi9Ye2JC/oIi4=
@@ -110,6 +115,7 @@ golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561/go.mod h1:cyybsKvd6eL0RnXn6p
 golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
 golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
 golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -97,9 +97,6 @@ schema = 3
   [mod."github.com/erikgeiser/coninput"]
     version = "v0.0.0-20211004153227-1c3628e74d0f"
     hash = "sha256-OWSqN1+IoL73rWXWdbbcahZu8n2al90Y3eT5Z0vgHvU="
-  [mod."github.com/fatih/color"]
-    version = "v1.18.0"
-    hash = "sha256-pP5y72FSbi4j/BjyVq/XbAOFjzNjMxZt2R/lFFxGWvY="
   [mod."github.com/inconshreveable/mousetrap"]
     version = "v1.1.0"
     hash = "sha256-XWlYH0c8IcxAwQTnIi6WYqq44nOKUylSWxWO/vi+8pE="
@@ -109,9 +106,6 @@ schema = 3
   [mod."github.com/lucasb-eyer/go-colorful"]
     version = "v1.2.0"
     hash = "sha256-Gg9dDJFCTaHrKHRR1SrJgZ8fWieJkybljybkI9x0gyE="
-  [mod."github.com/mattn/go-colorable"]
-    version = "v0.1.13"
-    hash = "sha256-qb3Qbo0CELGRIzvw7NVM1g/aayaz4Tguppk9MD2/OI8="
   [mod."github.com/mattn/go-isatty"]
     version = "v0.0.20"
     hash = "sha256-qhw9hWtU5wnyFyuMbKx+7RB8ckQaFQ8D+8GKPkN3HHQ="

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -97,6 +97,9 @@ schema = 3
   [mod."github.com/erikgeiser/coninput"]
     version = "v0.0.0-20211004153227-1c3628e74d0f"
     hash = "sha256-OWSqN1+IoL73rWXWdbbcahZu8n2al90Y3eT5Z0vgHvU="
+  [mod."github.com/fatih/color"]
+    version = "v1.18.0"
+    hash = "sha256-pP5y72FSbi4j/BjyVq/XbAOFjzNjMxZt2R/lFFxGWvY="
   [mod."github.com/inconshreveable/mousetrap"]
     version = "v1.1.0"
     hash = "sha256-XWlYH0c8IcxAwQTnIi6WYqq44nOKUylSWxWO/vi+8pE="
@@ -106,6 +109,9 @@ schema = 3
   [mod."github.com/lucasb-eyer/go-colorful"]
     version = "v1.2.0"
     hash = "sha256-Gg9dDJFCTaHrKHRR1SrJgZ8fWieJkybljybkI9x0gyE="
+  [mod."github.com/mattn/go-colorable"]
+    version = "v0.1.13"
+    hash = "sha256-qb3Qbo0CELGRIzvw7NVM1g/aayaz4Tguppk9MD2/OI8="
   [mod."github.com/mattn/go-isatty"]
     version = "v0.0.20"
     hash = "sha256-qhw9hWtU5wnyFyuMbKx+7RB8ckQaFQ8D+8GKPkN3HHQ="

--- a/selector/root.go
+++ b/selector/root.go
@@ -52,7 +52,7 @@ func (cs ClientSelectors) Cluster(ctx context.Context) (*types.Cluster, error) {
 		form := huh.NewForm(
 			huh.NewGroup(
 				huh.NewSelect[string]().
-					Title("Cluster").
+					Title("Select a cluster").
 					Options(
 						huh.NewOptions(clusterArns...)...,
 					).
@@ -96,7 +96,7 @@ func (cs ClientSelectors) Service(
 		form := huh.NewForm(
 			huh.NewGroup(
 				huh.NewSelect[string]().
-					Title("Service").
+					Title("Select a cluster").
 					Options(huh.NewOptions(serviceArns...)...).
 					Value(&selectedServiceArn).
 					WithHeight(5),
@@ -108,7 +108,11 @@ func (cs ClientSelectors) Service(
 		}
 	}
 
-	services, err := cs.client.DescribeServices(ctx, *cluster.ClusterArn, []string{selectedServiceArn})
+	services, err := cs.client.DescribeServices(
+		ctx,
+		*cluster.ClusterArn,
+		[]string{selectedServiceArn},
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -139,7 +143,7 @@ func (cs ClientSelectors) Task(
 		form := huh.NewForm(
 			huh.NewGroup(
 				huh.NewSelect[string]().
-					Title("Select task").
+					Title("Select a task").
 					Options(huh.NewOptions(taskArns...)...).
 					Value(&selectedTaskArn).
 					WithHeight(5),
@@ -181,14 +185,14 @@ func (cs ClientSelectors) Tasks(
 		form := huh.NewForm(
 			huh.NewGroup(
 				huh.NewMultiSelect[string]().
-					Title("Task(s)").
+					Title("Select at least one task").
 					Options(huh.NewOptions(taskArns...)...).
 					Value(&selectedTaskArns).
 					Validate(func(s []string) error {
 						if len(s) > 0 {
 							return nil
 						}
-						return fmt.Errorf("select at least one task")
+						return fmt.Errorf("no task selected")
 					}),
 			),
 		)
@@ -227,7 +231,7 @@ func (cs ClientSelectors) Container(
 		form := huh.NewForm(
 			huh.NewGroup(
 				huh.NewSelect[string]().
-					Title("Select container").
+					Title("Select a container").
 					Options(huh.NewOptions(containerNames...)...).
 					Value(&containerName).
 					WithHeight(5),
@@ -270,14 +274,14 @@ func (cs ClientSelectors) ContainerDefinitions(
 		form := huh.NewForm(
 			huh.NewGroup(
 				huh.NewMultiSelect[string]().
-					Title("Containers").
+					Title("Select at least one container").
 					Options(huh.NewOptions(containerNames...)...).
 					Value(&selectedContainerNames).
 					Validate(func(s []string) error {
 						if len(s) > 0 {
 							return nil
 						}
-						return fmt.Errorf("select at least one container")
+						return fmt.Errorf("no container selected")
 					}),
 			),
 		)

--- a/selector/root.go
+++ b/selector/root.go
@@ -254,6 +254,7 @@ func (cs ClientSelectors) Container(
 	for _, container := range task.Containers {
 		containerNames = append(containerNames, *container.Name)
 	}
+
 	var containerName string
 	if len(containerNames) == 1 {
 		log.Printf("Pre-selecting the only available container")
@@ -272,12 +273,14 @@ func (cs ClientSelectors) Container(
 			return nil, err
 		}
 	}
+
 	for _, container := range task.Containers {
 		if *container.Name == containerName {
 			fmt.Printf("%s %s\n", titleStyle.Render("Container:"), *container.Name)
 			return &container, nil
 		}
 	}
+
 	return nil, fmt.Errorf("container not found: %s", containerName)
 }
 

--- a/selector/root.go
+++ b/selector/root.go
@@ -242,14 +242,14 @@ func (cs ClientSelectors) ContainerDefinitions(
 	form := huh.NewForm(
 		huh.NewGroup(
 			huh.NewMultiSelect[string]().
-				Title("Select container definition").
+				Title("Containers").
 				Options(huh.NewOptions(containerNames...)...).
 				Value(&selectedContainerNames).
 				Validate(func(s []string) error {
 					if len(s) > 0 {
 						return nil
 					}
-					return fmt.Errorf("no container(s) selected")
+					return fmt.Errorf("select at least one container")
 				}),
 		),
 	)

--- a/selector/root.go
+++ b/selector/root.go
@@ -22,6 +22,7 @@ type Selectors interface {
 	Service(ctx context.Context, cluster *types.Cluster) (*types.Service, error)
 	Task(ctx context.Context, service *types.Service) (*types.Task, error)
 	Container(ctx context.Context, task *types.Task) (*types.Container, error)
+	Tasks(ctx context.Context, service *types.Service) ([]types.Task, error)
 	ContainerDefinitions(
 		ctx context.Context,
 		taskDefinitionArn string,
@@ -268,4 +269,58 @@ func (cs ClientSelectors) ContainerDefinitions(
 	}
 
 	return nil, fmt.Errorf("no containers selected")
+}
+
+func (cs ClientSelectors) Tasks(
+	ctx context.Context,
+	service *types.Service,
+) ([]types.Task, error) {
+	listTasksOutput, err := cs.client.ListTasks(ctx, &ecs.ListTasksInput{
+		Cluster:     service.ClusterArn,
+		ServiceName: service.ServiceArn,
+	})
+	if err != nil {
+		return nil, err
+	}
+	taskArns := listTasksOutput.TaskArns
+	if len(taskArns) == 0 {
+		return nil, fmt.Errorf(
+			"no tasks found for service: %s in cluster: %s",
+			*service.ServiceArn,
+			*service.ClusterArn,
+		)
+	}
+
+	var selectedTaskArns []string
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewMultiSelect[string]().
+				Title("Tasks").
+				Options(huh.NewOptions(taskArns...)...).
+				Value(&selectedTaskArns).
+				Validate(func(s []string) error {
+					if len(s) > 0 {
+						return nil
+					}
+					return fmt.Errorf("select at least one task")
+				}),
+		),
+	)
+	if err = form.Run(); err != nil {
+		return nil, err
+	}
+
+	describeTasksOutput, err := cs.client.DescribeTasks(ctx, &ecs.DescribeTasksInput{
+		Cluster: service.ClusterArn,
+		Tasks:   selectedTaskArns,
+	})
+	if err != nil {
+		return nil, err
+	}
+	tasks := describeTasksOutput.Tasks
+	if len(tasks) == 0 {
+		return nil, fmt.Errorf("no tasks selected")
+	}
+
+	return tasks, nil
 }

--- a/selector/root.go
+++ b/selector/root.go
@@ -300,5 +300,10 @@ func (cs ClientSelectors) ContainerDefinitions(
 		return nil, fmt.Errorf("no containers selected")
 	}
 
+	fmt.Printf(
+		"%s %s\n",
+		titleStyle.Render("Container(s):"),
+		strings.Join(selectedContainerNames, ","),
+	)
 	return selectedContainers, nil
 }

--- a/selector/root.go
+++ b/selector/root.go
@@ -31,15 +31,15 @@ type Selectors interface {
 }
 
 type ClientSelectors struct {
-	client *ecs.Client
+	ecsClient *ecs.Client
 }
 
-func NewSelectors(client *ecs.Client) Selectors {
-	return ClientSelectors{client: client}
+func NewSelectors(ecsClient *ecs.Client) Selectors {
+	return ClientSelectors{ecsClient: ecsClient}
 }
 
 func (cs ClientSelectors) Cluster(ctx context.Context) (*types.Cluster, error) {
-	listClusters, err := cs.client.ListClusters(ctx, &ecs.ListClustersInput{})
+	listClusters, err := cs.ecsClient.ListClusters(ctx, &ecs.ListClustersInput{})
 	if err != nil {
 		return nil, err
 	}
@@ -70,7 +70,7 @@ func (cs ClientSelectors) Cluster(ctx context.Context) (*types.Cluster, error) {
 		}
 	}
 
-	describeClusters, err := cs.client.DescribeClusters(ctx, &ecs.DescribeClustersInput{
+	describeClusters, err := cs.ecsClient.DescribeClusters(ctx, &ecs.DescribeClustersInput{
 		Clusters: []string{selectedClusterArn},
 	})
 	if err != nil {
@@ -91,7 +91,7 @@ func (cs ClientSelectors) Service(
 	ctx context.Context,
 	cluster *types.Cluster,
 ) (*types.Service, error) {
-	listServices, err := cs.client.ListServices(ctx, &ecs.ListServicesInput{
+	listServices, err := cs.ecsClient.ListServices(ctx, &ecs.ListServicesInput{
 		Cluster: cluster.ClusterArn,
 	})
 	if err != nil {
@@ -123,7 +123,7 @@ func (cs ClientSelectors) Service(
 		}
 	}
 
-	describeServices, err := cs.client.DescribeServices(ctx, &ecs.DescribeServicesInput{
+	describeServices, err := cs.ecsClient.DescribeServices(ctx, &ecs.DescribeServicesInput{
 		Cluster:  cluster.ClusterArn,
 		Services: []string{selectedServiceArn},
 	})
@@ -145,7 +145,7 @@ func (cs ClientSelectors) Task(
 	ctx context.Context,
 	service *types.Service,
 ) (*types.Task, error) {
-	listTasks, err := cs.client.ListTasks(ctx, &ecs.ListTasksInput{
+	listTasks, err := cs.ecsClient.ListTasks(ctx, &ecs.ListTasksInput{
 		Cluster:     service.ClusterArn,
 		ServiceName: service.ServiceArn,
 	})
@@ -181,7 +181,7 @@ func (cs ClientSelectors) Task(
 		}
 	}
 
-	describeTasks, err := cs.client.DescribeTasks(ctx, &ecs.DescribeTasksInput{
+	describeTasks, err := cs.ecsClient.DescribeTasks(ctx, &ecs.DescribeTasksInput{
 		Cluster: service.ClusterArn,
 		Tasks:   []string{selectedTaskArn},
 	})
@@ -203,7 +203,7 @@ func (cs ClientSelectors) Tasks(
 	ctx context.Context,
 	service *types.Service,
 ) ([]types.Task, error) {
-	listTasksOutput, err := cs.client.ListTasks(ctx, &ecs.ListTasksInput{
+	listTasksOutput, err := cs.ecsClient.ListTasks(ctx, &ecs.ListTasksInput{
 		Cluster:     service.ClusterArn,
 		ServiceName: service.ServiceArn,
 	})
@@ -245,7 +245,7 @@ func (cs ClientSelectors) Tasks(
 	}
 
 	fmt.Printf("%s %s\n", titleStyle.Render("Task(s):"), strings.Join(selectedTaskArns, ","))
-	describeTasks, err := cs.client.DescribeTasks(ctx, &ecs.DescribeTasksInput{
+	describeTasks, err := cs.ecsClient.DescribeTasks(ctx, &ecs.DescribeTasksInput{
 		Cluster: service.ClusterArn,
 		Tasks:   selectedTaskArns,
 	})
@@ -303,7 +303,7 @@ func (cs ClientSelectors) ContainerDefinitions(
 	ctx context.Context,
 	taskDefinitionArn string,
 ) ([]types.ContainerDefinition, error) {
-	describeTaskDefinition, err := cs.client.DescribeTaskDefinition(
+	describeTaskDefinition, err := cs.ecsClient.DescribeTaskDefinition(
 		ctx,
 		&ecs.DescribeTaskDefinitionInput{
 			TaskDefinition: &taskDefinitionArn,


### PR DESCRIPTION
This pull request introduces significant enhancements to the `client` package and related command files (`cmd/logs.go`, `cmd/exec.go`) to improve functionality for interacting with AWS ECS and CloudWatch Logs. The key changes include extending the `Client` interface for additional ECS operations, refactoring the logging functionality to support multiple containers and tasks, and updating tests to reflect the new structure.

### Enhancements to ECS and CloudWatch Logs functionality:

#### Client interface updates:
* Added methods to the `Client` interface for listing and describing ECS clusters, services, tasks, and task definitions. These methods provide more granular control over ECS resources. (`client/client.go`, [[1]](diffhunk://#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09L7-R48) [[2]](diffhunk://#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09R60-R65) [[3]](diffhunk://#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09R86-R175) [[4]](diffhunk://#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09L74-R235)

#### Logging functionality improvements:
* Refactored the `StartLiveTail` method to handle multiple containers and tasks, enabling simultaneous log tailing across multiple streams. Introduced the `LiveTailHandlers` struct to replace the previous `EventHandler` for better event handling. (`client/client.go`, [client/client.goL130-R267](diffhunk://#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09L130-R267))
* Updated the `runLogs` function to dynamically generate log stream names based on task and container information, supporting parallel log tailing with synchronization using `sync.WaitGroup`. (`cmd/logs.go`, [cmd/logs.goR38-R150](diffhunk://#diff-e6824e1936e82569dca8cc8a16f0b68ec37bfd4c057700032fb0587747c2373fR38-R150))

### Refactoring and testing updates:

#### Code refactoring:
* Replaced the `SelectedContainerDefinition` type with the more comprehensive `LogsSelection` type, which includes cluster, service, tasks, and containers. This change improves the structure and readability of log selection logic. (`cmd/logs.go`, [[1]](diffhunk://#diff-e6824e1936e82569dca8cc8a16f0b68ec37bfd4c057700032fb0587747c2373fR6-R23) [[2]](diffhunk://#diff-e6824e1936e82569dca8cc8a16f0b68ec37bfd4c057700032fb0587747c2373fL116-R175)
* Updated imports and removed unused ECS client references in `cmd/exec.go` and `cmd/logs.go` to streamline dependencies. (`cmd/exec.go`, [[1]](diffhunk://#diff-ce92eefe0908ac93cdc54bd33b7d01c347c159ae09a9324bd0479acdbc38c442L15) [[2]](diffhunk://#diff-ce92eefe0908ac93cdc54bd33b7d01c347c159ae09a9324bd0479acdbc38c442L61-R65); `cmd/logs.go`, [[3]](diffhunk://#diff-e6824e1936e82569dca8cc8a16f0b68ec37bfd4c057700032fb0587747c2373fR6-R23)

#### Test updates:
* Refactored tests in `cmd/logs_test.go` to align with the new `LogsSelection` structure. Added mock tasks and updated assertions to validate log configuration and options. (`cmd/logs_test.go`, [[1]](diffhunk://#diff-22e518acf530a844ab4051bf614550b8ebfca84040fb558fab1c4fc3c2b0fed8R27-R67) [[2]](diffhunk://#diff-22e518acf530a844ab4051bf614550b8ebfca84040fb558fab1c4fc3c2b0fed8R107-R138) [[3]](diffhunk://#diff-22e518acf530a844ab4051bf614550b8ebfca84040fb558fab1c4fc3c2b0fed8R160-R203)

### Documentation update:
* Added a new section to `GEMINI.md` detailing the process for building and running tests using `go test`. (`GEMINI.md`, [GEMINI.mdR1-R7](diffhunk://#diff-399080f41ccf73c6004e0f85c0a58fc1767080a0ef19bb3f3a90caa14f94bd79R1-R7))