### PR TITLE
feat: Add support for themes

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -39,6 +39,11 @@ var execCmd = &cobra.Command{
   env AWS_PROFILE=<profile> iecs exec [flags]
   `,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		theme, err := themeByName(themeName)
+		if err != nil {
+			return err
+		}
+
 		smpPath, err := exec.LookPath("session-manager-plugin")
 		if err != nil {
 			return err
@@ -62,7 +67,7 @@ var execCmd = &cobra.Command{
 			smpPath,
 			awsClient,
 			exec.Command,
-			selector.NewSelectors(awsClient),
+			selector.NewSelectors(awsClient, *theme),
 			cfg.Region,
 			command,
 			interactive,

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -31,6 +31,11 @@ var logsCmd = &cobra.Command{
   env AWS_PROFILE=<profile> iecs logs [flags]
   `,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		theme, err := themeByName(themeName)
+		if err != nil {
+			return err
+		}
+
 		cfg, err := config.LoadDefaultConfig(context.TODO())
 		if err != nil {
 			return err
@@ -40,7 +45,7 @@ var logsCmd = &cobra.Command{
 		err = runLogs(
 			context.TODO(),
 			client,
-			selector.NewSelectors(client),
+			selector.NewSelectors(client, *theme),
 		)
 		if err != nil {
 			return err

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,8 +2,25 @@ package cmd
 
 import (
 	_ "embed"
+	"fmt"
+	"log"
+	"strings"
 
+	"github.com/charmbracelet/huh"
 	"github.com/spf13/cobra"
+)
+
+const (
+	ThemeBase       string = "base"
+	ThemeBase16     string = "base16"
+	ThemeCatppuccin string = "catppuccin"
+	ThemeCharm      string = "charm"
+	ThemeDracula    string = "dracula"
+)
+
+var (
+	themes    = []string{ThemeBase, ThemeBase16, ThemeCatppuccin, ThemeCharm, ThemeDracula}
+	themeName string
 )
 
 var rootCmd = &cobra.Command{
@@ -14,10 +31,36 @@ var rootCmd = &cobra.Command{
 }
 
 func Execute(version string) error {
+	rootCmd.PersistentFlags().
+		StringVarP(&themeName, "theme", "t", "charm", fmt.Sprintf("The theme to use. Available themes are: %s", strings.Join(themes, " ")))
 	rootCmd.Version = version
+
 	err := rootCmd.Execute()
 	if err != nil {
 		return err
 	}
+
 	return nil
+}
+
+func themeByName(themeName string) (*huh.Theme, error) {
+	log.Printf("Selected theme %s\n", themeName)
+	switch themeName {
+	case ThemeBase:
+		return huh.ThemeBase(), nil
+	case ThemeBase16:
+		return huh.ThemeBase16(), nil
+	case ThemeCatppuccin:
+		return huh.ThemeCatppuccin(), nil
+	case ThemeCharm:
+		return huh.ThemeCharm(), nil
+	case ThemeDracula:
+		return huh.ThemeDracula(), nil
+	default:
+		return nil, fmt.Errorf(
+			"unsupported theme '%s' expecting one of: %s",
+			themeName,
+			strings.Join(themes, " "),
+		)
+	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,7 +32,16 @@ var rootCmd = &cobra.Command{
 
 func Execute(version string) error {
 	rootCmd.PersistentFlags().
-		StringVarP(&themeName, "theme", "t", "charm", fmt.Sprintf("The theme to use. Available themes are: %s", strings.Join(themes, " ")))
+		StringVarP(
+			&themeName,
+			"theme",
+			"t",
+			"charm",
+			fmt.Sprintf(
+				"The theme to use. Available themes are: %s",
+				strings.Join(themes, " "),
+			),
+		)
 	rootCmd.Version = version
 
 	err := rootCmd.Execute()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	_ "embed"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/charmbracelet/huh"
@@ -53,7 +52,6 @@ func Execute(version string) error {
 }
 
 func themeByName(themeName string) (*huh.Theme, error) {
-	log.Printf("Selected theme %s\n", themeName)
 	switch themeName {
 	case ThemeBase:
 		return huh.ThemeBase(), nil

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,67 +1,43 @@
 package cmd
 
 import (
+	"fmt"
+	"sort"
+	"strings"
 	"testing"
 
-	"github.com/charmbracelet/huh"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestThemeByName(t *testing.T) {
-	tests := []struct {
-		name          string
-		themeName     string
-		expectedTheme *huh.Theme
-		expectError   bool
-	}{
-		{
-			name:          "Base",
-			themeName:     ThemeBase,
-			expectedTheme: huh.ThemeBase(),
-			expectError:   false,
-		},
-		{
-			name:          "Base16",
-			themeName:     ThemeBase16,
-			expectedTheme: huh.ThemeBase16(),
-			expectError:   false,
-		},
-		{
-			name:          "Catppuccin",
-			themeName:     ThemeCatppuccin,
-			expectedTheme: huh.ThemeCatppuccin(),
-			expectError:   false,
-		},
-		{
-			name:          "Charm",
-			themeName:     ThemeCharm,
-			expectedTheme: huh.ThemeCharm(),
-			expectError:   false,
-		},
-		{
-			name:          "Dracula",
-			themeName:     ThemeDracula,
-			expectedTheme: huh.ThemeDracula(),
-			expectError:   false,
-		},
-		{
-			name:          "Invalid",
-			themeName:     "invalid",
-			expectedTheme: nil,
-			expectError:   true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			theme, err := themeByName(tt.themeName)
-			if tt.expectError {
-				assert.Error(t, err)
-				assert.Nil(t, theme)
-			} else {
+	t.Run("Valid Themes", func(t *testing.T) {
+		for name, themeFunc := range themes {
+			t.Run(name, func(t *testing.T) {
+				theme, err := themeByName(name)
 				assert.NoError(t, err)
-				assert.Equal(t, tt.expectedTheme, theme)
-			}
-		})
-	}
+				assert.NotNil(t, theme)
+				assert.Equal(t, themeFunc(), theme)
+			})
+		}
+	})
+
+	t.Run("Invalid Theme", func(t *testing.T) {
+		invalidThemeName := "invalid-theme"
+		theme, err := themeByName(invalidThemeName)
+
+		var themeNames []string
+		for name := range themes {
+			themeNames = append(themeNames, name)
+		}
+		sort.Strings(themeNames)
+
+		expectedError := fmt.Sprintf(
+			"unsupported theme '%s' expecting one of: %s",
+			invalidThemeName,
+			strings.Join(themeNames, " "),
+		)
+
+		assert.EqualError(t, err, expectedError)
+		assert.Nil(t, theme)
+	})
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -22,14 +22,21 @@ func TestThemeByName(t *testing.T) {
 	})
 
 	t.Run("Invalid Theme", func(t *testing.T) {
+		// Backup and restore the global themeNames variable to ensure test isolation.
+		originalThemeNames := themeNames
+		defer func() { themeNames = originalThemeNames }()
+
+		// To test the error message correctly, we need to populate the global
+		// themeNames slice, which is normally done in the Execute function.
+		var names []string
+		for name := range themes {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		themeNames = names
+
 		invalidThemeName := "invalid-theme"
 		theme, err := themeByName(invalidThemeName)
-
-		var themeNames []string
-		for name := range themes {
-			themeNames = append(themeNames, name)
-		}
-		sort.Strings(themeNames)
 
 		expectedError := fmt.Sprintf(
 			"unsupported theme '%s' expecting one of: %s",

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/huh"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestThemeByName(t *testing.T) {
+	tests := []struct {
+		name          string
+		themeName     string
+		expectedTheme *huh.Theme
+		expectError   bool
+	}{
+		{
+			name:          "Base",
+			themeName:     ThemeBase,
+			expectedTheme: huh.ThemeBase(),
+			expectError:   false,
+		},
+		{
+			name:          "Base16",
+			themeName:     ThemeBase16,
+			expectedTheme: huh.ThemeBase16(),
+			expectError:   false,
+		},
+		{
+			name:          "Catppuccin",
+			themeName:     ThemeCatppuccin,
+			expectedTheme: huh.ThemeCatppuccin(),
+			expectError:   false,
+		},
+		{
+			name:          "Charm",
+			themeName:     ThemeCharm,
+			expectedTheme: huh.ThemeCharm(),
+			expectError:   false,
+		},
+		{
+			name:          "Dracula",
+			themeName:     ThemeDracula,
+			expectedTheme: huh.ThemeDracula(),
+			expectError:   false,
+		},
+		{
+			name:          "Invalid",
+			themeName:     "invalid",
+			expectedTheme: nil,
+			expectError:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			theme, err := themeByName(tt.themeName)
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Nil(t, theme)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedTheme, theme)
+			}
+		})
+	}
+}

--- a/devenv.nix
+++ b/devenv.nix
@@ -13,8 +13,8 @@
   languages.go.enable = true;
 
   git-hooks.hooks = {
-    gofmt.enable = true;
     golangci-lint.enable = true;
+    golines.enable = true;
     gomod2nix = {
       enable = true;
       entry = "${pkgs.gomod2nix}/bin/gomod2nix";

--- a/selector/root.go
+++ b/selector/root.go
@@ -32,10 +32,11 @@ type Selectors interface {
 
 type ClientSelectors struct {
 	client client.Client
+	theme  huh.Theme
 }
 
-func NewSelectors(client client.Client) Selectors {
-	return ClientSelectors{client: client}
+func NewSelectors(client client.Client, theme huh.Theme) Selectors {
+	return ClientSelectors{client: client, theme: theme}
 }
 
 func (cs ClientSelectors) Cluster(ctx context.Context) (*types.Cluster, error) {
@@ -59,7 +60,7 @@ func (cs ClientSelectors) Cluster(ctx context.Context) (*types.Cluster, error) {
 					Value(&selectedClusterArn).
 					WithHeight(5),
 			),
-		)
+		).WithTheme(&cs.theme)
 		if err = form.Run(); err != nil {
 			return nil, err
 		}
@@ -101,7 +102,7 @@ func (cs ClientSelectors) Service(
 					Value(&selectedServiceArn).
 					WithHeight(5),
 			),
-		)
+		).WithTheme(&cs.theme)
 
 		if err = form.Run(); err != nil {
 			return nil, err
@@ -148,7 +149,7 @@ func (cs ClientSelectors) Task(
 					Value(&selectedTaskArn).
 					WithHeight(5),
 			),
-		)
+		).WithTheme(&cs.theme)
 		if err = form.Run(); err != nil {
 			return nil, err
 		}
@@ -195,7 +196,7 @@ func (cs ClientSelectors) Tasks(
 						return fmt.Errorf("no task selected")
 					}),
 			),
-		)
+		).WithTheme(&cs.theme)
 		if err = form.Run(); err != nil {
 			return nil, err
 		}
@@ -236,7 +237,7 @@ func (cs ClientSelectors) Container(
 					Value(&containerName).
 					WithHeight(5),
 			),
-		)
+		).WithTheme(&cs.theme)
 		if err := form.Run(); err != nil {
 			return nil, err
 		}
@@ -284,7 +285,7 @@ func (cs ClientSelectors) ContainerDefinitions(
 						return fmt.Errorf("no container selected")
 					}),
 			),
-		)
+		).WithTheme(&cs.theme)
 		if err = form.Run(); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This pull request introduces theme support across the CLI commands and refactors the selector logic to integrate themes. Additionally, it updates the development environment configuration to use a new linting tool. The most important changes are grouped by theme-related enhancements and development environment updates.

### Theme-related enhancements:

* [`cmd/root.go`](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR5-R25): Added a new `theme` flag to the CLI, allowing users to specify a theme for the interface. Defined constants for available themes and implemented a helper function `themeByName` to retrieve themes by name. [[1]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR5-R25) [[2]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR34-R75)
* `cmd/exec.go` and `cmd/logs.go`: Integrated theme selection into the `exec` and `logs` commands by calling `themeByName` and passing the selected theme to `selector.NewSelectors`. [[1]](diffhunk://#diff-ce92eefe0908ac93cdc54bd33b7d01c347c159ae09a9324bd0479acdbc38c442R42-R46) [[2]](diffhunk://#diff-ce92eefe0908ac93cdc54bd33b7d01c347c159ae09a9324bd0479acdbc38c442L65-R70) [[3]](diffhunk://#diff-e6824e1936e82569dca8cc8a16f0b68ec37bfd4c057700032fb0587747c2373fR34-R38) [[4]](diffhunk://#diff-e6824e1936e82569dca8cc8a16f0b68ec37bfd4c057700032fb0587747c2373fL43-R48)
* [`selector/root.go`](diffhunk://#diff-5816173f7c5845bc87c78235e6353470b1910efea85ebaea3d93876a74f08fa0R35-R39): Updated the `ClientSelectors` struct to include a `theme` field and modified the `NewSelectors` function to accept a theme parameter. Applied the theme to various selector methods using `.WithTheme(&cs.theme)`. [[1]](diffhunk://#diff-5816173f7c5845bc87c78235e6353470b1910efea85ebaea3d93876a74f08fa0R35-R39) [[2]](diffhunk://#diff-5816173f7c5845bc87c78235e6353470b1910efea85ebaea3d93876a74f08fa0L62-R63) [[3]](diffhunk://#diff-5816173f7c5845bc87c78235e6353470b1910efea85ebaea3d93876a74f08fa0L104-R105) [[4]](diffhunk://#diff-5816173f7c5845bc87c78235e6353470b1910efea85ebaea3d93876a74f08fa0L151-R152) [[5]](diffhunk://#diff-5816173f7c5845bc87c78235e6353470b1910efea85ebaea3d93876a74f08fa0L198-R199) [[6]](diffhunk://#diff-5816173f7c5845bc87c78235e6353470b1910efea85ebaea3d93876a74f08fa0L239-R240) [[7]](diffhunk://#diff-5816173f7c5845bc87c78235e6353470b1910efea85ebaea3d93876a74f08fa0L287-R288)

### Development environment updates:

* [`devenv.nix`](diffhunk://#diff-cef540503c67fa4a36d1b9fe95a62f979c4b8b2bc43a6e023e250b7154341afcL16-R17): Replaced the `gofmt` git hook with `golines`, a tool for formatting Go code with line length limits.