### PR TITLE
ci: Extract package derivation to a separate file / Setup secretspec

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,25 @@
+{ lib
+, nix-filter
+, pkgs
+, pname ? "iecs"
+, tags ? [ ]
+,
+}:
+
+pkgs.buildGoApplication {
+  inherit pname tags;
+  version = lib.trim (builtins.readFile ./version.txt);
+  src = nix-filter {
+    root = ./.;
+    include = [
+      "client"
+      "cmd"
+      "selector"
+      ./go.mod
+      ./go.sum
+      ./main.go
+      ./version.txt
+    ];
+  };
+  modules = ./gomod2nix.toml;
+}

--- a/devenv.lock
+++ b/devenv.lock
@@ -1,12 +1,32 @@
 {
   "nodes": {
+    "auto-commit-msg": {
+      "inputs": {
+        "gomod2nix": "gomod2nix",
+        "nix-filter": "nix-filter",
+        "nixpkgs": "nixpkgs",
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1761102815,
+        "owner": "sestrella",
+        "repo": "auto-commit-msg",
+        "rev": "d447a1f6806f6407c2365b0027ce26d1cda315d0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sestrella",
+        "repo": "auto-commit-msg",
+        "type": "github"
+      }
+    },
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1752269046,
+        "lastModified": 1761091275,
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "c6df749ce20b18910745a4c39c3d77c06fbcdcc6",
+        "rev": "a795c32dc826b51d12706f27fb344f966bb2b084",
         "type": "github"
       },
       "original": {
@@ -48,6 +68,23 @@
         "type": "github"
       }
     },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_3"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "git-hooks": {
       "inputs": {
         "flake-compat": "flake-compat",
@@ -57,10 +94,10 @@
         ]
       },
       "locked": {
-        "lastModified": 1750779888,
+        "lastModified": 1760663237,
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "16ec914f6fb6f599ce988427d9d94efddf25fe6d",
+        "rev": "ca5b894d3e3e151ffc1db040b6ce4dcc75d31c37",
         "type": "github"
       },
       "original": {
@@ -92,13 +129,16 @@
     "gomod2nix": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": [
+          "auto-commit-msg",
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1751702058,
+        "lastModified": 1756047880,
         "owner": "nix-community",
         "repo": "gomod2nix",
-        "rev": "664ad7a2df4623037e315e4094346bff5c44e9ee",
+        "rev": "47d628dc3b506bd28632e47280c6b89d3496909d",
         "type": "github"
       },
       "original": {
@@ -107,12 +147,59 @@
         "type": "github"
       }
     },
+    "gomod2nix_2": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1759991118,
+        "owner": "nix-community",
+        "repo": "gomod2nix",
+        "rev": "7f8d7438f5870eb167abaf2c39eea3d2302019d1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "gomod2nix",
+        "type": "github"
+      }
+    },
+    "nix-filter": {
+      "locked": {
+        "lastModified": 1757882181,
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "rev": "59c44d1909c72441144b93cf0f054be7fe764de5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1752366256,
+        "lastModified": 1760878510,
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "5e2a59a5b1a82f89f2c7e598302a9cacebb72a67",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1761102505,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "89d01f29ee586f24139d6832d92dca35190e6fa6",
+        "rev": "5e2e9c2ea67c5ae6a70f55476a0fd195c08581be",
         "type": "github"
       },
       "original": {
@@ -122,33 +209,62 @@
         "type": "github"
       }
     },
-    "nixpkgs_2": {
+    "nixpkgs_3": {
       "locked": {
-        "lastModified": 1752012998,
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "2a2130494ad647f953593c4e84ea4df839fbd68c",
+        "lastModified": 1758532697,
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "207a4cb0e1253c7658c6736becc6eb9cace1f25f",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
+        "auto-commit-msg": "auto-commit-msg",
         "devenv": "devenv",
         "git-hooks": "git-hooks",
-        "gomod2nix": "gomod2nix",
-        "nixpkgs": "nixpkgs_2",
+        "gomod2nix": "gomod2nix_2",
+        "nixpkgs": "nixpkgs_3",
         "pre-commit-hooks": [
           "git-hooks"
         ]
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_3": {
       "locked": {
         "lastModified": 1681028828,
         "owner": "nix-systems",

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,6 +1,12 @@
-{ pkgs, ... }:
+{ config
+, lib
+, pkgs
+, ...
+}:
 
 {
+  env.GEMINI_API_KEY = config.secretspec.secrets.GEMINI_API_KEY or "";
+
   packages = [
     pkgs.asciinema
     pkgs.asciinema-agg
@@ -14,6 +20,12 @@
   languages.go.enable = true;
 
   git-hooks.hooks = {
+    auto-commit-msg = {
+      enable = true;
+      entry = lib.getExe pkgs.auto-commit-msg;
+      stages = [ "prepare-commit-msg" ];
+      verbose = true;
+    };
     golangci-lint.enable = true;
     golines.enable = true;
     gomod2nix = {

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,8 +1,15 @@
 # yaml-language-server: $schema=https://devenv.sh/devenv.schema.json
 inputs:
-  nixpkgs:
-    url: github:nixos/nixpkgs/nixpkgs-unstable
+  auto-commit-msg:
+    url: github:sestrella/auto-commit-msg
+    overlays: [default]
   gomod2nix:
     url: github:nix-community/gomod2nix
-    overlays:
-      - default
+    overlays: [default]
+  nixpkgs:
+    url: github:cachix/devenv-nixpkgs/rolling
+
+secretspec:
+  enable: true
+  provider: keyring
+  profile: development

--- a/secretspec.toml
+++ b/secretspec.toml
@@ -1,0 +1,10 @@
+[project]
+name = "iecs"
+revision = "1.0"
+
+[profiles.default]
+GEMINI_API_KEY = { description = "Google Gemini API key", required = false }
+
+[profiles.development]
+# Development profile inherits all secrets from default profile
+# Only define secrets here that need different values or settings than default


### PR DESCRIPTION
This commit introduces the `iecs` project and configures the development environment using `devenv`.

Key changes include:

- **`default.nix`**: Defines the build logic for the `iecs` Go application.
- **`devenv.lock`**: Updates dependencies and adds `auto-commit-msg` and `flake-utils`.
- **`devenv.nix`**: Enables Go development, configures language settings, and adds `auto-commit-msg` as a git hook. It also sets up the `GEMINI_API_KEY` environment variable.
- **`devenv.yaml`**: Configures inputs for `auto-commit-msg`, `gomod2nix`, and `nixpkgs`. It also sets up `secretspec` for managing secrets.
- **`flake.nix`**: Updates flake inputs and outputs to include `nix-filter` and `auto-commit-msg`, and refactors package definitions to use `default.nix`.
- **`secretspec.toml`**: Defines project secrets and profiles for `GEMINI_API_KEY`.
