### PR TITLE
chore: Pass theme directly to Selectors

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -51,7 +51,7 @@ var execCmd = &cobra.Command{
 
 		awsClient := client.NewClient(cfg)
 
-		selection, err := execSelector(context.TODO(), selector.NewSelectors(awsClient, theme))
+		selection, err := execSelector(context.TODO(), selector.NewSelectors(awsClient, *theme))
 		if err != nil {
 			return err
 		}

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -53,7 +53,7 @@ var logsCmd = &cobra.Command{
 
 		client := client.NewClient(cfg)
 
-		selection, err := logsSelector(context.TODO(), selector.NewSelectors(client, theme))
+		selection, err := logsSelector(context.TODO(), selector.NewSelectors(client, *theme))
 		if err != nil {
 			return err
 		}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -29,7 +29,7 @@ var updateCmd = &cobra.Command{
 		}
 
 		client := client.NewClient(cfg)
-		selectors := selector.NewSelectors(client, theme)
+		selectors := selector.NewSelectors(client, *theme)
 
 		selection, err := updateSelector(
 			context.Background(),

--- a/selector/root.go
+++ b/selector/root.go
@@ -22,17 +22,8 @@ type Selectors struct {
 	theme  huh.Theme
 }
 
-var Themes = map[string]func() *huh.Theme{
-	"base":       huh.ThemeBase,
-	"base16":     huh.ThemeBase16,
-	"catppuccin": huh.ThemeCatppuccin,
-	"charm":      huh.ThemeCharm,
-	"dracula":    huh.ThemeDracula,
-}
-
-func NewSelectors(client client.Client, themeName string) Selectors {
-	theme := Themes[themeName]()
-	return Selectors{client: client, theme: *theme}
+func NewSelectors(client client.Client, theme huh.Theme) Selectors {
+	return Selectors{client: client, theme: theme}
 }
 
 func (s Selectors) Cluster(


### PR DESCRIPTION
The `huh` library has been updated, and the way themes are handled has changed. Previously, themes were selected by a string name from a map of functions. Now, themes are directly passed as `*huh.Theme` objects.

This commit updates the `rootCmd` to handle the theme selection using the new approach. It also updates the `NewSelectors` function in `selector/root.go` to accept a `huh.Theme` directly. Additionally, the `execCmd`, `logsCmd`, and `updateCmd` have been adjusted to pass the selected theme correctly.
